### PR TITLE
ブラウザ向けにビルドできるよう未使用の機能フラグを無効化

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -19,7 +19,7 @@ sha2 = "0.10.8"
 curve25519-dalek = { version = "4.1.2", features = ["legacy_compatibility"] }
 digest = "0.10.7"
 cipher = "0.4.4"
-aes-gcm = "0.10.3"
+aes-gcm = { version="0.10.3", default-features = false, features = ["aes","alloc"] }
 bip39 = "2.0.0"
 hmac = "0.12.1"
 crypto-common = "0.1.6"


### PR DESCRIPTION
`aes-gcm`のデフォルトで有効の機能フラグ`getrandom`が有効になっているためターゲット`wasm32-unknown-unknown`でビルドすると`libc`が機能フラグ`js`なしにビルドされて失敗します。